### PR TITLE
[TASK] Allow db host config

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -203,14 +203,14 @@ class Config
         return $this;
     }
 
-    public function useDDEVConfiguration(): self
+    public function useDDEVConfiguration(string $dbHost = 'db'): self
     {
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['trustedHostsPattern'] = '.*.*';
         $this
             ->initializeDatabaseConnection(
                 [
                     'dbname' => 'db',
-                    'host' => 'db',
+                    'host' => $dbHost,
                     'password' => 'db',
                     'port' => '3306',
                     'user' => 'db',

--- a/src/Config.php
+++ b/src/Config.php
@@ -203,14 +203,14 @@ class Config
         return $this;
     }
 
-    public function useDDEVConfiguration(string $dbHost = 'db'): self
+    public function useDDEVConfiguration(string $dbHost = null): self
     {
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['trustedHostsPattern'] = '.*.*';
         $this
             ->initializeDatabaseConnection(
                 [
                     'dbname' => 'db',
-                    'host' => $dbHost,
+                    'host' => $dbHost ?? ('ddev-' . getenv('DDEV_PROJECT') . '-db'),
                     'password' => 'db',
                     'port' => '3306',
                     'user' => 'db',


### PR DESCRIPTION
Allows the usage of another db host name,  like

``` 
\B13\Config::get()
    ->useDDEVConfiguration(
        'ddev-' . getenv('DDEV_PROJECT') . '-db'
    );