### PR TITLE
[FEATURE] Add logic to exclude multiple hash parameters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,6 @@
     "classmap": ["src/"]
   },
   "require-dev": {
-    "typo3/coding-standards": "^0.4.0"
+    "typo3/coding-standards": "^0.6"
   }
 }

--- a/examples/extended/AdditionalConfiguration.php
+++ b/examples/extended/AdditionalConfiguration.php
@@ -18,8 +18,8 @@ class ProjectConfig extends \B13\Config
         $GLOBALS['TYPO3_CONF_VARS']['LOG']['MyVendor']['MyPath']['writerConfiguration'] = [
             $logLevel => [
                 \TYPO3\CMS\Core\Log\Writer\FileWriter::class => [
-                    'logFile' => $this->varPath . '/log/' . $fileName
-                ]
+                    'logFile' => $this->varPath . '/log/' . $fileName,
+                ],
             ],
         ];
         return $this;


### PR DESCRIPTION
* Adds "excludeQueryParametersForCacheHashCalculation()"
* Adds "useMailpit" as alias for "useMailhog"
* Adds support for unneeded pagesection cache in v12
* Updates coding-standards to v0.6